### PR TITLE
Fixes vh inconsistency on mobile (#32)

### DIFF
--- a/components/Content/About.tsx
+++ b/components/Content/About.tsx
@@ -5,7 +5,7 @@ import styles from 'styles/components/about.module.scss';
 
 export default function About({...props}) {
   return (
-    <div {...props} className={`${styles.section} flex flex-col items-center`}>
+    <div {...props} className={`${styles.section} flex flex-col items-center pt-12`}>
       <h1 className="text-3xl my-8 font-bold">— About Me —</h1>
       <div className={`${styles.card} flex p-6 items-center flex-col`}>
         <div className={`${styles.photo_container} flex rounded-full bg-white`}>

--- a/components/Content/Contact.tsx
+++ b/components/Content/Contact.tsx
@@ -43,7 +43,7 @@ export default function Contact({...props}) {
   };
 
   return (
-    <div {...props} className={`${styles.section} flex flex-col`}>
+    <div {...props} className={`${styles.section} flex flex-col min-h-screen`}>
       <h1 className="text-3xl my-8 font-bold self-center">— Contact Me —</h1>
       <form
         className={`${styles.form} flex flex-col self-center m-3 md:px-2`}

--- a/components/Content/Portfolio.tsx
+++ b/components/Content/Portfolio.tsx
@@ -6,7 +6,7 @@ import styles from 'styles/components/portfolio.module.scss';
 
 export default function Portfolio({...props}) {
   return (
-    <div {...props} className={`${styles.section} flex flex-col`}>
+    <div {...props} className={`${styles.section} flex flex-col pt-12`}>
       <h1 className="text-3xl my-8 font-bold self-center">— Portfolio —</h1>
       <div className={`${styles.card} my-3`}>
         <div className={`${styles.site_image} relative overflow-hidden lg:w-1/2 lg:float-left`}>

--- a/components/Content/Skills.tsx
+++ b/components/Content/Skills.tsx
@@ -52,7 +52,7 @@ const skillSet = [
 
 export default function Skills({...props}) {
   return (
-    <div {...props} className={`${styles.section} flex flex-col`}>
+    <div {...props} className={`${styles.section} flex flex-col pt-12`}>
       <h1 className="text-3xl my-8 font-bold self-center">— Skills —</h1>
       <div
         className={`${styles.skills_container} flex flex-wrap justify-evenly md:justify-around`}>

--- a/components/Navs/NavBar.tsx
+++ b/components/Navs/NavBar.tsx
@@ -65,9 +65,9 @@ export default function NavBar({
   return (
     <nav
       {...props}
-      className={`${styles.navbar} flex fixed w-full z-20 px-3 md:absolute md:px-9`}>
+      className={`${styles.navbar} flex fixed w-full z-20 p-3 md:absolute md:px-9 md:py-6`}>
       <Link href="/">
-        <a className={styles.home_link}>
+        <a className={`${styles.home_link} ml-3 mr-auto`}>
           <div className="h-12">
             <Image
               height={44}
@@ -80,7 +80,7 @@ export default function NavBar({
       </Link>
       <ul className="flex items-center">
         <SocialLinks />
-        <li className="flex m-3">
+        <li className="flex mx-3">
           <Link href="/contact">
             <a>
               <div className={`${styles.contact} px-4 py-2`}>
@@ -90,7 +90,7 @@ export default function NavBar({
           </Link>
         </li>
         {displayMenu && (
-          <li className="flex m-3">
+          <li className="flex mx-3">
             <button
               onClick={handleClick}
               className={`${styles.bars} rounded h-11 w-11`}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "with-typescript-styled-components",
+  "name": "danielslovinsky.com",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -37,10 +37,10 @@ export default function Home() {
             height={calcH}
             resolution={10}
             streak={0.5}
-            className="absolute h-screen"
+            className={`${styles.gol} absolute`}
           />
         )}
-        <Title id="Home" className="h-screen" />
+        <Title id="Home" />
         <About id="About" />
         <Portfolio id="Portfolio" />
         <Skills id="Skills" />

--- a/styles/components/about.module.scss
+++ b/styles/components/about.module.scss
@@ -2,7 +2,7 @@
 @use '../partials/breakpoints';
 
 .section {
-  min-height: calc(var(--vh, 1vh) * 66);
+  min-height: 38rem;
 
   > .card {
     background-color: colors.$black-pearl-lite;

--- a/styles/components/contact.module.scss
+++ b/styles/components/contact.module.scss
@@ -4,7 +4,6 @@
 
 .section {
   padding: 10% 0;
-  min-height: calc(var(--vh, 1vh) * 100);
 
   form {
     max-width: 800px;

--- a/styles/components/navbar.module.scss
+++ b/styles/components/navbar.module.scss
@@ -8,23 +8,15 @@ nav.navbar {
     background-color: rgba(black, 0);
   }
 
-  > .home_link {
-    margin: 12px auto 12px 12px;
-
-    @media screen and (min-width: breakpoints.$medium) and (min-height: breakpoints.$x-small) {
-      margin: 24px auto 24px 12px;
-    }
-
-    > div {
+  > .home_link  > div {
       border: solid 2px rgba(red, 0.8);
-    }
   }
 
   > ul {
     > li {
       &.social_item {
         display: none;
-        margin: 12px;
+        margin: 0 12px;
 
         @media screen and (min-width: breakpoints.$small) {
           display: flex;

--- a/styles/components/portfolio.module.scss
+++ b/styles/components/portfolio.module.scss
@@ -2,10 +2,10 @@
 @use '../partials/breakpoints';
 
 .section {
-  min-height: calc(var(--vh, 1vh) * 75);
+  min-height: 40rem;
 
   @media screen and (min-width: breakpoints.$large) {
-    height: 646px;
+    height: 40rem;
   }
 
   .card {
@@ -27,7 +27,7 @@
     }
 
     .site_image {
-      height: calc(var(--vh, 1vh) * 25);
+      height: 13.5rem;
       margin: 0 4%;
 
       @media screen and (min-width: breakpoints.$large) {

--- a/styles/components/skills.module.scss
+++ b/styles/components/skills.module.scss
@@ -2,7 +2,7 @@
 @use '../partials/breakpoints.scss';
 
 .section {
-  min-height: calc(var(--vh, 1vh) * 66);
+  min-height: 32rem;
 
   > .skills_container {
     background-color: colors.$black-pearl-lite;

--- a/styles/index.module.scss
+++ b/styles/index.module.scss
@@ -5,8 +5,12 @@
 .main {
   background-color: colors.$black-pearl;
 
+  .gol {
+    max-height: 100vh;
+  }
+
   .profile_container {
-    height: calc(var(--vh, 1vh) * 100);
+    height: 100vh;
 
     @media screen and (min-height: breakpoints.$x-small) {
       justify-content: center;


### PR DESCRIPTION
* Attempts to fix vh problem by removing height from useViewHeight dependencies

* Separate vh solution by fixing vh calc on title and GoL to use calc

* Attempts to prevent vh movement by switching title and GoL only to regular vh

* Removes vh where possible and reorganizes styling to prevent navbar from overlapping titles at small widths